### PR TITLE
fix: register operation completion listener with BuildServiceRegistry

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,10 +21,8 @@ jobs:
           distribution: adopt
           architecture: x64
 
-      - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
 
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2.4.2
-        with:
-          arguments: check
+        run: ./gradlew check

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.1.1-SNAPSHOT
+version=3.1.2-SNAPSHOT

--- a/src/main/groovy/net/researchgate/release/BzrAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/BzrAdapter.groovy
@@ -10,16 +10,16 @@
 
 package net.researchgate.release
 
+import groovy.transform.CompileStatic
 import org.gradle.api.GradleException
-import org.gradle.api.Project
 
-class BzrAdapter extends BaseScmAdapter {
+class BzrAdapter extends BaseScmAdapter<Cacheable> {
 
     private static final String ERROR = 'ERROR'
     private static final String DELIM = '\n  * '
 
-    BzrAdapter(Project project, Map<String, Object> attributes) {
-        super(project, attributes)
+    BzrAdapter(PluginHelper pluginHelper) {
+        super(pluginHelper, new Cacheable(cacheablePluginHelper: pluginHelper.toCacheable()))
     }
 
     @Override
@@ -120,8 +120,12 @@ class BzrAdapter extends BaseScmAdapter {
         exec(['bzr', 'add', file.path], errorMessage: "Error adding file ${file.name}", errorPatterns: [ERROR])
     }
 
-    @Override
-    void revert() {
-        exec(['bzr', 'revert', findPropertiesFile().name], errorMessage: 'Error reverting changes made by the release plugin.', errorPatterns: [ERROR])
+    @CompileStatic
+    static class Cacheable extends BaseScmAdapter.Cacheable {
+
+        @Override
+        void revert() {
+            exec(['bzr', 'revert', propertiesFile.name], errorMessage: 'Error reverting changes made by the release plugin.', errorPatterns: [ERROR])
+        }
     }
 }

--- a/src/main/groovy/net/researchgate/release/ExternalizableUtils.groovy
+++ b/src/main/groovy/net/researchgate/release/ExternalizableUtils.groovy
@@ -1,0 +1,35 @@
+package net.researchgate.release
+
+import org.gradle.api.provider.Property
+
+class ExternalizableUtils {
+    static void writeNullableStringProperty(ObjectOutput objectOutput, Property<String> stringProperty) {
+        if (stringProperty.isPresent()) {
+            objectOutput.writeBoolean(true)
+            objectOutput.writeUTF(stringProperty.get())
+        } else {
+            objectOutput.writeBoolean(false)
+        }
+    }
+
+    static void writeNullableBooleanProperty(ObjectOutput objectOutput, Property<Boolean> booleanProperty) {
+        if (booleanProperty.isPresent()) {
+            objectOutput.writeBoolean(true)
+            objectOutput.writeBoolean(booleanProperty.get())
+        } else {
+            objectOutput.writeBoolean(false)
+        }
+    }
+
+    static void readNullableStringProperty(ObjectInput objectInput, Property<String> stringProperty) throws IOException {
+        if (objectInput.readBoolean()) {
+            stringProperty.set(objectInput.readUTF())
+        }
+    }
+
+    static void readNullableBooleanProperty(ObjectInput objectInput, Property<Boolean> booleanProperty) throws IOException {
+        if (objectInput.readBoolean()) {
+            booleanProperty.set(objectInput.readBoolean())
+        }
+    }
+}

--- a/src/main/groovy/net/researchgate/release/HgAdapter.groovy
+++ b/src/main/groovy/net/researchgate/release/HgAdapter.groovy
@@ -10,14 +10,14 @@
 
 package net.researchgate.release
 
-import org.gradle.api.Project
+import groovy.transform.CompileStatic
 
-class HgAdapter extends BaseScmAdapter {
+class HgAdapter extends BaseScmAdapter<Cacheable> {
 
     private static final String ERROR = 'abort:'
 
-    HgAdapter(Project project, Map<String, Object> attributes) {
-        super(project, attributes)
+    HgAdapter(PluginHelper pluginHelper) {
+        super(pluginHelper, new Cacheable(cacheablePluginHelper: pluginHelper.toCacheable()))
     }
 
     @Override
@@ -90,12 +90,16 @@ class HgAdapter extends BaseScmAdapter {
         exec(['hg', 'add', file.path], errorMessage: "Error adding file ${file.name}", errorPatterns: [ERROR])
     }
 
-    @Override
-    void revert() {
-        exec(['hg', 'revert', findPropertiesFile().name], errorMessage: 'Error reverting changes made by the release plugin.', errorPatterns: [ERROR])
-    }
-
     private String hgCurrentBranch() {
         exec(['hg', 'branch']).readLines()[0]
+    }
+
+    @CompileStatic
+    static class Cacheable extends BaseScmAdapter.Cacheable {
+
+        @Override
+        void revert() {
+            exec(['hg', 'revert', propertiesFile.name], errorMessage: 'Error reverting changes made by the release plugin.', errorPatterns: [ERROR])
+        }
     }
 }

--- a/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
+++ b/src/main/groovy/net/researchgate/release/ReleasePlugin.groovy
@@ -30,29 +30,26 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.BasePlugin
-import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.GradleBuild
 import org.gradle.api.tasks.TaskState
-import org.gradle.build.event.BuildEventsListenerRegistry
-import org.gradle.tooling.events.OperationCompletionListener
-import org.gradle.tooling.events.task.TaskFailureResult
 import org.gradle.util.GradleVersion
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 import javax.inject.Inject
 
-abstract class ReleasePlugin extends PluginHelper implements Plugin<Project> {
+abstract class ReleasePlugin implements Plugin<Project> {
     static final String RELEASE_GROUP = 'Release'
-
-    private BaseScmAdapter scmAdapter
 
     void apply(Project project) {
         if (!project.plugins.hasPlugin(BasePlugin.class)) {
             project.plugins.apply(BasePlugin.class)
         }
-        this.project = project
-        extension = project.extensions.create('release', ReleaseExtension, project, attributes)
+        Map<String, Object> attributes = [:]
+        def extension = project.extensions.create('release', ReleaseExtension, project, attributes)
+        def pluginHelper = new PluginHelper(project, extension, attributes)
 
-        String preCommitText = findProperty('release.preCommitText', null, 'preCommitText')
+        String preCommitText = pluginHelper.findProperty('release.preCommitText', null, 'preCommitText')
         if (preCommitText) {
             extension.preCommitText.convention(preCommitText)
         }
@@ -90,7 +87,7 @@ abstract class ReleasePlugin extends PluginHelper implements Plugin<Project> {
         project.task('afterReleaseBuild', group: RELEASE_GROUP,
                 description: 'Runs immediately after the build when doing a release') {}
         project.task('createScmAdapter', group: RELEASE_GROUP,
-                description: 'Finds the correct SCM plugin') doLast this.&createScmAdapter
+                description: 'Finds the correct SCM plugin') doLast { createScmAdapter(pluginHelper) }
 
         project.tasks.create('initScmAdapter', InitScmAdapter)
         project.tasks.create('checkCommitNeeded', CheckCommitNeeded.class)
@@ -170,33 +167,43 @@ abstract class ReleasePlugin extends PluginHelper implements Plugin<Project> {
         if (GradleVersion.current() < GradleVersion.version('6.1')) {
             project.gradle.taskGraph.afterTask { Task task, TaskState state ->
                 if (state.failure && task.name == 'release') {
-                    revert()
+                    BaseScmAdapter scmAdapter = null
+                    try {
+                        scmAdapter = createScmAdapter(pluginHelper)
+                    } catch (Exception ignored) {}
+                    revert(
+                            scmAdapter?.toCacheable(),
+                            extension.revertOnFail.get(),
+                            project.file(extension.versionPropertyFile),
+                            project.logger ?: LoggerFactory.getLogger(this.class),
+                    )
                 }
             }
         } else {
+            def listenerClass = Class.forName("net.researchgate.release.RevertOnFailedReleaseTaskCompletionListener")
+            def revertOnFailedReleaseTaskCompletionListenerProvider = project.gradle.sharedServices
+                    .registerIfAbsent('revertOnFailedRelease', listenerClass) { spec ->
+                        BaseScmAdapter scmAdapter = null
+                        try {
+                            scmAdapter = createScmAdapter(pluginHelper)
+                        } catch (Exception ignored) {}
+                        spec.parameters.scmAdapter.set(scmAdapter?.toCacheable())
+                    }
+
             objects.newInstance(BuildEventsListenerRegistryProvider)
                   .buildEventsListenerRegistry
-                  .onTaskCompletion(providers.provider {
-                      { finishEvent ->
-                          if ((finishEvent.result instanceof TaskFailureResult) && finishEvent.descriptor.taskPath.endsWith(':release')) {
-                              revert()
-                          }
-                      } as OperationCompletionListener
-                  })
+                  .onTaskCompletion(revertOnFailedReleaseTaskCompletionListenerProvider)
         }
     }
 
     @Inject
     abstract protected ObjectFactory getObjects();
 
-    @Inject
-    abstract protected ProviderFactory getProviders();
-
-    protected revert() {
-        try {
-            createScmAdapter()
-        } catch (Exception ignored) {}
-        if (scmAdapter && extension.revertOnFail.get() && project.file(extension.versionPropertyFile)?.exists()) {
+    protected static void revert(BaseScmAdapter.Cacheable scmAdapter,
+                                 boolean revertOnFail,
+                                 File versionPropertyFile,
+                                 Logger log) {
+        if (scmAdapter && revertOnFail && versionPropertyFile?.exists()) {
             log.error('Release process failed, reverting back any changes made by Release Plugin.')
             scmAdapter.revert()
         } else {
@@ -204,27 +211,24 @@ abstract class ReleasePlugin extends PluginHelper implements Plugin<Project> {
         }
     }
 
-    void createScmAdapter() {
-        scmAdapter = findScmAdapter()
-        extension.scmAdapter = scmAdapter
-    }
-
-    void checkUpdateNeeded() {
-        scmAdapter.checkUpdateNeeded()
+    BaseScmAdapter createScmAdapter(PluginHelper pluginHelper) {
+        def scmAdapter = findScmAdapter(pluginHelper)
+        pluginHelper.extension.scmAdapter = scmAdapter
+        scmAdapter
     }
 
     /**
      * Recursively look for the type of the SCM we are dealing with, if no match is found look in parent directory
      * @param directory the directory to start from
      */
-    protected BaseScmAdapter findScmAdapter() {
+    protected BaseScmAdapter findScmAdapter(PluginHelper pluginHelper) {
         BaseScmAdapter adapter
-        File projectPath = project.projectDir.canonicalFile
+        File projectPath = pluginHelper.project.projectDir.canonicalFile
 
-        extension.scmAdapters.find {
+        pluginHelper.extension.scmAdapters.find {
             assert BaseScmAdapter.isAssignableFrom(it)
 
-            BaseScmAdapter instance = it.getConstructor(Project.class, Map.class).newInstance(project, attributes)
+            BaseScmAdapter instance = it.getConstructor(PluginHelper.class).newInstance(pluginHelper)
             if (instance.isSupported(projectPath)) {
                 adapter = instance
                 return true

--- a/src/main/groovy/net/researchgate/release/RevertOnFailedReleaseTaskCompletionListener.groovy
+++ b/src/main/groovy/net/researchgate/release/RevertOnFailedReleaseTaskCompletionListener.groovy
@@ -1,0 +1,27 @@
+package net.researchgate.release
+
+import org.gradle.api.provider.Property
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import org.gradle.tooling.events.FinishEvent
+import org.gradle.tooling.events.OperationCompletionListener
+import org.gradle.tooling.events.task.TaskFailureResult
+
+/**
+ * Listener to revert SCM changes on release task failure.
+ *
+ * <p>Requires Gradle 6.1+
+ */
+abstract class RevertOnFailedReleaseTaskCompletionListener
+        implements BuildService<Params>, OperationCompletionListener {
+    interface Params extends BuildServiceParameters {
+        Property<BaseScmAdapter.Cacheable> getScmAdapter();
+    }
+
+    @Override
+    void onFinish(FinishEvent finishEvent) {
+        if ((finishEvent.result instanceof TaskFailureResult) && finishEvent.descriptor.taskPath.endsWith(':release')) {
+            parameters.scmAdapter.get().revert()
+        }
+    }
+}

--- a/src/main/groovy/net/researchgate/release/tasks/BaseReleaseTask.groovy
+++ b/src/main/groovy/net/researchgate/release/tasks/BaseReleaseTask.groovy
@@ -2,6 +2,7 @@ package net.researchgate.release.tasks
 
 import groovy.text.SimpleTemplateEngine
 import net.researchgate.release.BaseScmAdapter
+import net.researchgate.release.PluginHelper
 import net.researchgate.release.ReleaseExtension
 import net.researchgate.release.ReleasePlugin
 import org.apache.tools.ant.BuildException
@@ -35,7 +36,7 @@ class BaseReleaseTask extends DefaultTask {
     @Internal
     BaseScmAdapter getScmAdapter() {
         if (extension.scmAdapter == null) {
-            project.getPlugins().getPlugin(ReleasePlugin.class).createScmAdapter()
+            project.getPlugins().getPlugin(ReleasePlugin.class).createScmAdapter(new PluginHelper(project, extension))
         }
         return extension.scmAdapter
     }

--- a/src/test/groovy/net/researchgate/release/GitReleasePluginCreateReleaseTagTests.groovy
+++ b/src/test/groovy/net/researchgate/release/GitReleasePluginCreateReleaseTagTests.groovy
@@ -62,7 +62,7 @@ class GitReleasePluginCreateReleaseTagTests extends GitSpecification {
         project = new ProjectBuilder().withProjectDir(localDir).build()
         project.plugins.apply(BasePlugin.class)
         project.plugins.apply(ReleasePlugin.class)
-        helper = new PluginHelper(project: project, extension: project.extensions['release'] as ReleaseExtension)
+        helper = new PluginHelper(project, project.extensions['release'] as ReleaseExtension)
     }
 
     def 'createReleaseTag should create tag and push to remote'() {

--- a/src/test/groovy/net/researchgate/release/GitReleasePluginTests.groovy
+++ b/src/test/groovy/net/researchgate/release/GitReleasePluginTests.groovy
@@ -31,6 +31,8 @@ class GitReleasePluginTests extends Specification {
 
     private Executor executor
 
+    private PluginHelper pluginHelper
+
     def setup() {
         testDir.mkdirs()
 
@@ -54,7 +56,8 @@ class GitReleasePluginTests extends Specification {
         this.executor.exec(['git', 'add', 'somename.txt'], failOnStderr: true, directory: localRepo, env: [:])
         this.executor.exec(['git', 'commit', "-m", "test", 'somename.txt'], failOnStderr: true, directory: localRepo, env: [:])
 
-        releasePlugin.createScmAdapter()
+        pluginHelper = new PluginHelper(project, project.extensions['release'] as ReleaseExtension)
+        releasePlugin.createScmAdapter(pluginHelper)
 
         def props = project.file("gradle.properties")
         props.withWriter { it << "version=${project.version}" }
@@ -69,7 +72,7 @@ class GitReleasePluginTests extends Specification {
         given:
         project.release.git.requireBranch.set('myBranch')
         when:
-        (new GitAdapter(project, [:])).init()
+        (new GitAdapter(pluginHelper)).init()
         then:
         GradleException ex = thrown()
         ex.message == 'Current Git branch is "master" and not "myBranch".'
@@ -79,7 +82,7 @@ class GitReleasePluginTests extends Specification {
         given:
         project.release.git.requireBranch.set(/myBranch|master/)
         when:
-        (new GitAdapter(project, [:])).init()
+        (new GitAdapter(pluginHelper)).init()
         then:
         noExceptionThrown()
     }

--- a/src/test/groovy/net/researchgate/release/PluginHelperTagNameTests.groovy
+++ b/src/test/groovy/net/researchgate/release/PluginHelperTagNameTests.groovy
@@ -27,12 +27,11 @@ public class PluginHelperTagNameTests extends Specification {
         project = ProjectBuilder.builder().withName("ReleasePluginTest").withProjectDir(testDir).build()
         project.version = '1.1'
         project.plugins.apply(BasePlugin.class)
-        ReleasePlugin releasePlugin = project.plugins.apply(ReleasePlugin.class)
-        project.extensions.release.scmAdapters = [TestAdapter]
+        ReleasePlugin releasePlugin = project.plugins.apply(TestReleasePlugin.class)
 
-        releasePlugin.createScmAdapter()
+        releasePlugin.createScmAdapter(new PluginHelper(project, project.extensions['release'] as ReleaseExtension))
 
-        helper = new PluginHelper(project: project, extension: project.extensions['release'] as ReleaseExtension)
+        helper = new PluginHelper(project, project.extensions['release'] as ReleaseExtension)
     }
 
     def 'by default the tag name is version'() {

--- a/src/test/groovy/net/researchgate/release/PluginHelperVersionPropertyFileTests.groovy
+++ b/src/test/groovy/net/researchgate/release/PluginHelperVersionPropertyFileTests.groovy
@@ -20,7 +20,7 @@ public class PluginHelperVersionPropertyFileTests extends Specification {
 
     Project project
 
-    PluginHelper helper
+    ReleasePlugin releasePlugin
 
     File testDir = new File("build/tmp/test/${getClass().simpleName}")
 
@@ -28,14 +28,14 @@ public class PluginHelperVersionPropertyFileTests extends Specification {
         project = ProjectBuilder.builder().withName("ReleasePluginTest").withProjectDir(testDir).build()
         project.version = '1.1'
         project.plugins.apply(BasePlugin.class)
-        ReleasePlugin releasePlugin = project.plugins.apply(ReleasePlugin.class)
-        project.extensions.release.scmAdapters = [TestAdapter]
-        releasePlugin.createScmAdapter()
-
-        helper = new PluginHelper(project: project, extension: project.extensions['release'] as ReleaseExtension)
+        releasePlugin = project.plugins.apply(TestReleasePlugin.class)
 
         def props = project.file("gradle.properties")
         props.withWriter {it << "version=${project.version}"}
+    }
+
+    PluginHelper getHelper() {
+        new PluginHelper(project, project.extensions['release'] as ReleaseExtension)
     }
 
     def cleanup() {
@@ -44,7 +44,7 @@ public class PluginHelperVersionPropertyFileTests extends Specification {
 
     def 'should find gradle.properties by default'() {
         expect:
-        helper.findPropertiesFile().name == 'gradle.properties'
+        helper.propertiesFile.name == 'gradle.properties'
     }
 
     def 'should find properties from convention'() {
@@ -55,7 +55,7 @@ public class PluginHelperVersionPropertyFileTests extends Specification {
             versionPropertyFile.set('custom.properties')
         }
         expect:
-        helper.findPropertiesFile().name == 'custom.properties'
+        helper.propertiesFile.name == 'custom.properties'
     }
 
     def 'by default should update `version` property from props file'() {

--- a/src/test/groovy/net/researchgate/release/ReleasePluginCheckSnapshotDependenciesTests.groovy
+++ b/src/test/groovy/net/researchgate/release/ReleasePluginCheckSnapshotDependenciesTests.groovy
@@ -26,10 +26,9 @@ public class ReleasePluginCheckSnapshotDependenciesTests extends Specification {
         project = ProjectBuilder.builder().withName("ReleasePluginTest").build()
         project.plugins.apply(BasePlugin.class)
         project.plugins.apply(GroovyPlugin.class)
-        ReleasePlugin releasePlugin = project.plugins.apply(ReleasePlugin.class)
-        project.extensions.release.scmAdapters = [TestAdapter]
+        ReleasePlugin releasePlugin = project.plugins.apply(TestReleasePlugin.class)
 
-        releasePlugin.createScmAdapter()
+        releasePlugin.createScmAdapter(new PluginHelper(project, project.extensions['release'] as ReleaseExtension))
     }
 
     def 'when no deps then no exception'() {

--- a/src/test/groovy/net/researchgate/release/ReleasePluginTests.groovy
+++ b/src/test/groovy/net/researchgate/release/ReleasePluginTests.groovy
@@ -36,10 +36,9 @@ class ReleasePluginTests extends Specification {
             w.write 'version=1.2\n'
         }
         project.plugins.apply(BasePlugin.class)
-        ReleasePlugin releasePlugin = project.plugins.apply(ReleasePlugin.class)
-        project.extensions.release.scmAdapters = [TestAdapter]
+        ReleasePlugin releasePlugin = project.plugins.apply(TestReleasePlugin.class)
 
-        releasePlugin.createScmAdapter()
+        releasePlugin.createScmAdapter(new PluginHelper(project, project.extensions['release'] as ReleaseExtension))
     }
 
     def 'plugin is successfully applied'() {

--- a/src/test/groovy/net/researchgate/release/TestAdapter.groovy
+++ b/src/test/groovy/net/researchgate/release/TestAdapter.groovy
@@ -10,12 +10,12 @@
 
 package net.researchgate.release
 
-import org.gradle.api.Project
+import groovy.transform.CompileStatic
 
 class TestAdapter extends BaseScmAdapter {
 
-    TestAdapter(Project project, Map<String, Object> attributes) {
-        super(project, attributes)
+    TestAdapter(PluginHelper pluginHelper) {
+        super(pluginHelper, new Cacheable(cacheablePluginHelper: pluginHelper.toCacheable()))
     }
 
     class TestConfig {
@@ -53,5 +53,13 @@ class TestAdapter extends BaseScmAdapter {
 
     @Override
     void revert() {
+    }
+
+    @CompileStatic
+    static class Cacheable extends BaseScmAdapter.Cacheable {
+
+        @Override
+        void revert() {
+        }
     }
 }

--- a/src/test/groovy/net/researchgate/release/TestReleasePlugin.groovy
+++ b/src/test/groovy/net/researchgate/release/TestReleasePlugin.groovy
@@ -1,0 +1,9 @@
+package net.researchgate.release
+
+abstract class TestReleasePlugin extends ReleasePlugin {
+
+    @Override
+    protected BaseScmAdapter findScmAdapter(PluginHelper pluginHelper) {
+        return new TestAdapter(pluginHelper)
+    }
+}


### PR DESCRIPTION
Gradle 9 doesn't allow using arbitrary providers as build events listeners when the Configuration Cache is used